### PR TITLE
feat(i18n): language switcher (en, pt-BR, es)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.2.0] – 2025-03-08
+
+### Added
+- feat(i18n): language switcher with English (default), pt-BR and Spanish
+- feat(store,main,preload): locale persistence and IPC get/set/onLocaleUpdated
+- feat(main): translate system notification messages (create note error, no notes to open) by locale
+- feat(ui): language selector in Main window; all UI strings use react-i18next
+
+### Chore & Tests
+- test(api): getLocale, setLocale, onLocaleUpdated IPC tests
+- test(main): language switcher combobox and setLocale on change
+- test(i18n): fix lint in test setup and main entry
+
 ## [1.1.0] – 2025-03-08
 
 ### Fixes
@@ -27,3 +40,4 @@
 - chore(deps): bump electron-builder to ^26.8.1
 
 [1.1.0]: https://github.com/Odisseu93/notifica-task/compare/v1.0.0...v1.1.0
+[1.2.0]: https://github.com/Odisseu93/notifica-task/compare/v1.1.0...v1.2.0

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ npm run dev
 You can download the latest version of Notifica Task for your platform:
 | Platform | Installer |
 | ---------- | ---------------------------------------------------------------------------------- |
+| 🪟 Windows (1.2.0) | <a download="" href="https://github.com/Odisseu93/notifica-task/raw/refs/heads/main/download/Notifica%20Task-Windows-1.2.0-Setup.exe">Download</a> |
 | 🪟 Windows (1.1.0) | <a download="" href="https://github.com/Odisseu93/notifica-task/raw/refs/heads/main/download/Notifica%20Task-Windows-1.1.0-Setup.exe">Download</a> |
 | 🪟 Windows (1.0.0) | <a download="" href="https://github.com/Odisseu93/notifica-task/raw/refs/heads/main/download/Notifica%20Task-Windows-1.0.0-Setup.exe">Download</a> |
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,7 +2,7 @@ import EventEmitter from 'node:events'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import path from 'node:path'
 
-import { app, BrowserWindow, ipcMain, Notification, Tray } from 'electron'
+import { app, BrowserWindow, ipcMain, Notification, screen, Tray } from 'electron'
 
 import { Note } from '../interfaces/note-interface'
 import { NoteNotification } from 'interfaces/note-notification-interface'
@@ -72,16 +72,25 @@ const saveNotesNotification = () => {
 	}
 }
 
+const MAIN_MENU_WIDTH = 320
+const MAIN_MENU_HEIGHT = 540
+
 const createMainWindow = () => {
 	const tray = new Tray(path.join(process.env.VITE_PUBLIC, 'icon.png'))
 	const trayBounds = tray.getBounds()
+	const display = screen.getDisplayNearestPoint({ x: trayBounds.x, y: trayBounds.y })
+	const workArea = display.workArea
+	const winHeight = Math.min(MAIN_MENU_HEIGHT, workArea.height)
+	const winWidth = Math.min(MAIN_MENU_WIDTH, workArea.width)
+	const x = Math.max(workArea.x, Math.min(trayBounds.x, workArea.x + workArea.width - winWidth))
+	const y = Math.max(workArea.y, Math.min(trayBounds.y - winHeight, workArea.y + workArea.height - winHeight))
 
 	mainWindow = new BrowserWindow({
 		icon: path.join(process.env.VITE_PUBLIC, 'icon.png'),
-		width: 225,
-		height: 520,
-		y: trayBounds.y + -520,
-		x: trayBounds.x,
+		width: winWidth,
+		height: winHeight,
+		x,
+		y,
 		resizable: false,
 		alwaysOnTop: true,
 		movable: false,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -29,6 +29,27 @@ let notesState: Record<string, Note> = store.get('notes') || {}
 let notesNotificationState: Record<string, NoteNotification> = store.get('notesNotification') || {}
 let activeNotesId: string[] = []
 
+const systemMessages: Record<LocaleCode, { errorTitle: string; createNoteError: string; noNotesTitle: string; noNotesToOpen: string }> = {
+	en: {
+		errorTitle: 'Error',
+		createNoteError: 'Could not create note.',
+		noNotesTitle: 'Alert',
+		noNotesToOpen: "You don't have any note to open!",
+	},
+	'pt-BR': {
+		errorTitle: 'Erro',
+		createNoteError: 'Não foi possível criar a nota.',
+		noNotesTitle: 'Aviso',
+		noNotesToOpen: 'Você não tem nenhuma nota para abrir!',
+	},
+	es: {
+		errorTitle: 'Error',
+		createNoteError: 'No se pudo crear la nota.',
+		noNotesTitle: 'Aviso',
+		noNotesToOpen: '¡No tienes ninguna nota para abrir!',
+	},
+}
+
 const eventEmitter = new EventEmitter()
 
 let notificationScheduleJob: schedule.Job | null = null
@@ -219,7 +240,9 @@ ipcMain.on('create-new-note', () => {
 		createNoteWindow(newNote)
 	} catch (err) {
 		console.error('[main] create-new-note failed:', err)
-		new Notification({ title: 'Error', body: 'Could not create note.' }).show()
+		const locale = (store.get('locale') as LocaleCode | undefined) ?? 'en'
+		const msg = systemMessages[locale]
+		new Notification({ title: msg.errorTitle, body: msg.createNoteError }).show()
 	}
 })
 
@@ -304,9 +327,11 @@ ipcMain.handle('delete-all-notes', () => {
 
 ipcMain.handle('open-all-notes', () => {
 	if (Object.keys(notesState).length === 0) {
+		const locale = (store.get('locale') as LocaleCode | undefined) ?? 'en'
+		const msg = systemMessages[locale]
 		new Notification({
-			title: 'alert',
-			body: "You don't have any note to open!",
+			title: msg.noNotesTitle,
+			body: msg.noNotesToOpen,
 		}).show()
 		return
 	}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,6 +8,7 @@ import { Note } from '../interfaces/note-interface'
 import { NoteNotification } from 'interfaces/note-notification-interface'
 import schedule from 'node-schedule'
 import store from './store'
+import type { LocaleCode } from './store'
 import { AlarmSoundKeyType } from '@/libs/app-notification'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -397,6 +398,31 @@ ipcMain.handle('set-auto-launch', (_, enable) => {
 	} catch (err) {
 		console.error('[main] set-auto-launch failed:', err)
 		return false
+	}
+})
+
+const VALID_LOCALES: LocaleCode[] = ['en', 'pt-BR', 'es']
+
+ipcMain.handle('get-locale', () => {
+	try {
+		return (store.get('locale') as LocaleCode | undefined) ?? 'en'
+	} catch (err) {
+		console.error('[main] get-locale failed:', err)
+		return 'en'
+	}
+})
+
+ipcMain.handle('set-locale', (_, locale: string) => {
+	const next = VALID_LOCALES.includes(locale as LocaleCode) ? (locale as LocaleCode) : 'en'
+	try {
+		store.set('locale', next)
+		if (!mainWindow.isDestroyed()) mainWindow.webContents.send('locale-updated', next)
+		windows.forEach((win) => {
+			if (!win.isDestroyed()) win.webContents.send('locale-updated', next)
+		})
+		if (aboutWindow && !aboutWindow.isDestroyed()) aboutWindow.webContents.send('locale-updated', next)
+	} catch (err) {
+		console.error('[main] set-locale failed:', err)
 	}
 })
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -82,4 +82,14 @@ contextBridge.exposeInMainWorld('electron', {
 	getAutoStart: () => ipcRenderer.invoke('get-auto-launch'),
 
 	setAutoStart: (enabled: boolean) => ipcRenderer.invoke('set-auto-launch', enabled),
+
+	getLocale: () => ipcRenderer.invoke('get-locale'),
+
+	setLocale: (locale: string) => ipcRenderer.invoke('set-locale', locale),
+
+	onLocaleUpdated: (callback: (locale: string) => void) => {
+		const listener = (_: unknown, locale: string) => callback(locale)
+		ipcRenderer.on('locale-updated', listener)
+		return () => ipcRenderer.removeListener('locale-updated', listener)
+	},
 })

--- a/electron/store/index.ts
+++ b/electron/store/index.ts
@@ -3,8 +3,11 @@ import { Note } from '../../interfaces/note-interface'
 import { NoteNotification } from '../../interfaces/note-notification-interface'
 import { AlarmSoundKeyType } from '@/libs/app-notification'
 
+export type LocaleCode = 'en' | 'pt-BR' | 'es'
+
 export default new Store<{
 	notesNotification: Record<string, NoteNotification>
 	notes: Record<string, Note>
 	notificationSound: AlarmSoundKeyType
+	locale?: LocaleCode
 }>()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notifica-task",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "@tailwindcss/vite": "^4.1.5",
     "class-variance-authority": "^0.7.1",
     "electron-store": "^10.0.1",
+    "i18next": "^25.8.14",
     "lucide-react": "^0.503.0",
     "node-schedule": "^2.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^16.5.6",
     "react-router-dom": "^7.6.1",
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.1.5"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,16 @@
+import { useEffect } from 'react'
 import RouteList from './RouteList'
+import { api } from '@/libs/api'
+import i18n from './i18n'
 
 function App() {
+	useEffect(() => {
+		const unsubscribe = api.onLocaleUpdated((locale) => {
+			i18n.changeLanguage(locale)
+		})
+		return unsubscribe
+	}, [])
+
 	return <RouteList />
 }
 

--- a/src/components/custom-select/styles.css
+++ b/src/components/custom-select/styles.css
@@ -7,7 +7,7 @@
 }
 
 .selected {
-  @apply bg-white flex justify-between w-[185px] px-4 py-2 border border-black rounded-md;
+  @apply bg-white flex justify-between w-full min-w-0 max-w-full px-4 py-2 border border-black rounded-md;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -26,7 +26,7 @@
 }
 
 .list--unfolded {
-  @apply absolute w-[185px] mt-[-5px] px-4 py-2 border border-t-0 border-black rounded-b-md;
+  @apply absolute w-full min-w-0 max-w-full mt-[-5px] px-4 py-2 border border-t-0 border-black rounded-b-md box-border;
   z-index: 1;
 }
 

--- a/src/components/main-window-button/styles.css
+++ b/src/components/main-window-button/styles.css
@@ -2,5 +2,5 @@
 @import "tw-animate-css";
 
 .button {
-  @apply max-w-[155px] px-4 py-2 border border-black rounded-md active:scale-95;
+  @apply w-full min-w-0 max-w-full px-4 py-2 border border-black rounded-md active:scale-95 whitespace-nowrap text-left;
 }

--- a/src/components/notification-schedule/index.test.tsx
+++ b/src/components/notification-schedule/index.test.tsx
@@ -7,7 +7,7 @@ import NotificationSchedule from './index'
 describe('NotificationSchedule', () => {
 	it('renders recurrence select and date input', async () => {
 		render(<NotificationSchedule noteId='test-note-id' />)
-		await screen.findByTitle('recurrence')
+		await screen.findByTitle('Recurrence')
 		expect(screen.getByPlaceholderText('date')).toBeInTheDocument()
 	})
 

--- a/src/components/notification-schedule/index.tsx
+++ b/src/components/notification-schedule/index.tsx
@@ -73,7 +73,7 @@ const NotificationSchedule = ({ noteId }: { noteId: string }) => {
 	return (
 		<>
 			<select
-				title='recurrence'
+				title={t('recurrence')}
 				aria-label={t('recurrence')}
 				className='recurrence-select'
 				value={noteNotification?.recurrence ?? ''}

--- a/src/components/notification-schedule/index.tsx
+++ b/src/components/notification-schedule/index.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, useLayoutEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { NoteNotification } from '../../../interfaces/note-notification-interface'
 import { api } from '../../libs/api'
@@ -7,6 +8,7 @@ import { now, formatDateTimeLocal } from '@/utils/date'
 const noteNotificationInitialState = {} as NoteNotification
 
 const NotificationSchedule = ({ noteId }: { noteId: string }) => {
+	const { t } = useTranslation('schedule')
 	const [noteNotification, setNoteNotification] = useState<NoteNotification>(noteNotificationInitialState)
 	const handleUpdateRecurrence = (e: ChangeEvent<HTMLSelectElement>) => {
 		const recurrence = e.target.value as NoteNotification['recurrence']
@@ -72,21 +74,21 @@ const NotificationSchedule = ({ noteId }: { noteId: string }) => {
 		<>
 			<select
 				title='recurrence'
-				aria-label='Recurrence'
+				aria-label={t('recurrence')}
 				className='recurrence-select'
 				value={noteNotification?.recurrence ?? ''}
 				onInput={handleUpdateRecurrence}
 			>
-				<option value=''>No recurrence</option>
-				<option value='daily'>Daily</option>
-				<option value='weekly'>Weekly</option>
-				<option value='monthly'>Monthly</option>
+				<option value=''>{t('noRecurrence')}</option>
+				<option value='daily'>{t('daily')}</option>
+				<option value='weekly'>{t('weekly')}</option>
+				<option value='monthly'>{t('monthly')}</option>
 			</select>
 
 			<input
-				placeholder='date'
+				placeholder={t('datePlaceholder')}
 				type='datetime-local'
-				aria-label='Schedule date and time'
+				aria-label={t('scheduleDateLabel')}
 				value={noteNotification.scheduleDate ? formatDateTimeLocal(noteNotification.scheduleDate) : ''}
 				onChange={handleUpdateScheduleDate}
 			/>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,48 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+import en from './locales/en.json'
+import ptBR from './locales/pt-BR.json'
+import es from './locales/es.json'
+
+const resources = {
+	en: {
+		main: en.main,
+		note: en.note,
+		about: en.about,
+		schedule: en.schedule,
+		sounds: en.sounds,
+		system: en.system,
+		language: en.language,
+	},
+	'pt-BR': {
+		main: ptBR.main,
+		note: ptBR.note,
+		about: ptBR.about,
+		schedule: ptBR.schedule,
+		sounds: ptBR.sounds,
+		system: ptBR.system,
+		language: ptBR.language,
+	},
+	es: {
+		main: es.main,
+		note: es.note,
+		about: es.about,
+		schedule: es.schedule,
+		sounds: es.sounds,
+		system: es.system,
+		language: es.language,
+	},
+}
+
+i18n.use(initReactI18next).init({
+	resources,
+	fallbackLng: 'en',
+	defaultNS: 'main',
+	ns: ['main', 'note', 'about', 'schedule', 'sounds', 'system', 'language'],
+	interpolation: {
+		escapeValue: false,
+	},
+})
+
+export default i18n

--- a/src/index.css
+++ b/src/index.css
@@ -39,3 +39,10 @@
 
   @apply text-gray-700 text-base;
 }
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}

--- a/src/libs/api.test.ts
+++ b/src/libs/api.test.ts
@@ -57,4 +57,24 @@ describe('API (IPC contract)', () => {
 		await api.openAllNotes()
 		expect(window.electron.openAllNotes).toHaveBeenCalled()
 	})
+
+	it('getLocale() calls electron and returns Promise<string>', async () => {
+		vi.mocked(window.electron.getLocale).mockResolvedValueOnce('pt-BR')
+		const result = await api.getLocale()
+		expect(window.electron.getLocale).toHaveBeenCalled()
+		expect(result).toBe('pt-BR')
+	})
+
+	it('setLocale(locale) calls electron with locale', async () => {
+		await api.setLocale('es')
+		expect(window.electron.setLocale).toHaveBeenCalledWith('es')
+	})
+
+	it('onLocaleUpdated(callback) returns unsubscribe and callback receives locale', () => {
+		const callback = vi.fn()
+		const unsubscribe = api.onLocaleUpdated(callback)
+		expect(typeof unsubscribe).toBe('function')
+		expect(window.electron.onLocaleUpdated).toHaveBeenCalledWith(callback)
+		unsubscribe()
+	})
 })

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -37,6 +37,9 @@ declare global {
 			closeApp: () => Promise<void>
 			getAutoStart: () => Promise<boolean>
 			setAutoStart: (enabled: boolean) => Promise<boolean>
+			getLocale: () => Promise<string>
+			setLocale: (locale: string) => Promise<void>
+			onLocaleUpdated: (callback: (locale: string) => void) => () => void
 		}
 	}
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -7,7 +7,8 @@
 		"deleteAllNotes": "Delete all notes",
 		"startupWithSystem": "Startup with system",
 		"about": "About",
-		"quit": "Quit"
+		"quit": "Quit",
+		"closeWindow": "Close main window"
 	},
 	"note": {
 		"loading": "Loading note...",
@@ -24,7 +25,8 @@
 		"chromeVersion": "Chrome Version:",
 		"platformAndArch": "Platform and Architecture:",
 		"developedBy": "Developed by:",
-		"loading": "Loading..."
+		"loading": "Loading...",
+		"closeWindow": "Close about window"
 	},
 	"schedule": {
 		"recurrence": "Recurrence",
@@ -32,7 +34,8 @@
 		"daily": "Daily",
 		"weekly": "Weekly",
 		"monthly": "Monthly",
-		"datePlaceholder": "date"
+		"datePlaceholder": "date",
+		"scheduleDateLabel": "Schedule date and time"
 	},
 	"sounds": {
 		"default": "Default sound",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,54 @@
+{
+	"main": {
+		"soundLabel": "Sound:",
+		"newNote": "New note",
+		"closeAllNotes": "Close all notes",
+		"openAllNotes": "Open all notes",
+		"deleteAllNotes": "Delete all notes",
+		"startupWithSystem": "Startup with system",
+		"about": "About",
+		"quit": "Quit"
+	},
+	"note": {
+		"loading": "Loading note...",
+		"addNote": "Add new note",
+		"openMenu": "Open menu",
+		"deleteNote": "Delete note",
+		"closeNote": "Close note window",
+		"placeholder": "Meeting at 8 am..."
+	},
+	"about": {
+		"version": "Version:",
+		"electronVersion": "Electron Version:",
+		"nodeVersion": "Node Version:",
+		"chromeVersion": "Chrome Version:",
+		"platformAndArch": "Platform and Architecture:",
+		"developedBy": "Developed by:",
+		"loading": "Loading..."
+	},
+	"schedule": {
+		"recurrence": "Recurrence",
+		"noRecurrence": "No recurrence",
+		"daily": "Daily",
+		"weekly": "Weekly",
+		"monthly": "Monthly",
+		"datePlaceholder": "date"
+	},
+	"sounds": {
+		"default": "Default sound",
+		"chime": "Chime",
+		"achievement": "Achievement bells",
+		"relaxingBell": "Relaxing bell"
+	},
+	"system": {
+		"errorTitle": "Error",
+		"createNoteError": "Could not create note.",
+		"noNotesToOpen": "You don't have any note to open!",
+		"alarmForNote": "Alarm for note: {{content}}"
+	},
+	"language": {
+		"en": "English",
+		"pt-BR": "Português",
+		"es": "Español"
+	}
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -52,6 +52,7 @@
 	"language": {
 		"en": "English",
 		"pt-BR": "Português",
-		"es": "Español"
+		"es": "Español",
+		"label": "Language"
 	}
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -52,6 +52,7 @@
 	"language": {
 		"en": "English",
 		"pt-BR": "Português",
-		"es": "Español"
+		"es": "Español",
+		"label": "Idioma"
 	}
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -7,7 +7,8 @@
 		"deleteAllNotes": "Eliminar todas las notas",
 		"startupWithSystem": "Iniciar con el sistema",
 		"about": "Acerca de",
-		"quit": "Salir"
+		"quit": "Salir",
+		"closeWindow": "Cerrar ventana principal"
 	},
 	"note": {
 		"loading": "Cargando nota...",
@@ -24,7 +25,8 @@
 		"chromeVersion": "Versión de Chrome:",
 		"platformAndArch": "Plataforma y arquitectura:",
 		"developedBy": "Desarrollado por:",
-		"loading": "Cargando..."
+		"loading": "Cargando...",
+		"closeWindow": "Cerrar ventana Acerca de"
 	},
 	"schedule": {
 		"recurrence": "Recurrencia",
@@ -32,7 +34,8 @@
 		"daily": "Diario",
 		"weekly": "Semanal",
 		"monthly": "Mensual",
-		"datePlaceholder": "fecha"
+		"datePlaceholder": "fecha",
+		"scheduleDateLabel": "Fecha y hora del recordatorio"
 	},
 	"sounds": {
 		"default": "Sonido predeterminado",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,0 +1,54 @@
+{
+	"main": {
+		"soundLabel": "Sonido:",
+		"newNote": "Nueva nota",
+		"closeAllNotes": "Cerrar todas las notas",
+		"openAllNotes": "Abrir todas las notas",
+		"deleteAllNotes": "Eliminar todas las notas",
+		"startupWithSystem": "Iniciar con el sistema",
+		"about": "Acerca de",
+		"quit": "Salir"
+	},
+	"note": {
+		"loading": "Cargando nota...",
+		"addNote": "Añadir nueva nota",
+		"openMenu": "Abrir menú",
+		"deleteNote": "Eliminar nota",
+		"closeNote": "Cerrar ventana de nota",
+		"placeholder": "Reunión a las 8..."
+	},
+	"about": {
+		"version": "Versión:",
+		"electronVersion": "Versión de Electron:",
+		"nodeVersion": "Versión de Node:",
+		"chromeVersion": "Versión de Chrome:",
+		"platformAndArch": "Plataforma y arquitectura:",
+		"developedBy": "Desarrollado por:",
+		"loading": "Cargando..."
+	},
+	"schedule": {
+		"recurrence": "Recurrencia",
+		"noRecurrence": "Sin recurrencia",
+		"daily": "Diario",
+		"weekly": "Semanal",
+		"monthly": "Mensual",
+		"datePlaceholder": "fecha"
+	},
+	"sounds": {
+		"default": "Sonido predeterminado",
+		"chime": "Campana",
+		"achievement": "Campanas de logro",
+		"relaxingBell": "Campana relajante"
+	},
+	"system": {
+		"errorTitle": "Error",
+		"createNoteError": "No se pudo crear la nota.",
+		"noNotesToOpen": "¡No tienes ninguna nota para abrir!",
+		"alarmForNote": "Alarma de nota: {{content}}"
+	},
+	"language": {
+		"en": "English",
+		"pt-BR": "Português",
+		"es": "Español"
+	}
+}

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -1,0 +1,54 @@
+{
+	"main": {
+		"soundLabel": "Som:",
+		"newNote": "Nova nota",
+		"closeAllNotes": "Fechar todas as notas",
+		"openAllNotes": "Abrir todas as notas",
+		"deleteAllNotes": "Excluir todas as notas",
+		"startupWithSystem": "Iniciar com o sistema",
+		"about": "Sobre",
+		"quit": "Sair"
+	},
+	"note": {
+		"loading": "Carregando nota...",
+		"addNote": "Adicionar nova nota",
+		"openMenu": "Abrir menu",
+		"deleteNote": "Excluir nota",
+		"closeNote": "Fechar janela da nota",
+		"placeholder": "Reunião às 8h..."
+	},
+	"about": {
+		"version": "Versão:",
+		"electronVersion": "Versão do Electron:",
+		"nodeVersion": "Versão do Node:",
+		"chromeVersion": "Versão do Chrome:",
+		"platformAndArch": "Plataforma e arquitetura:",
+		"developedBy": "Desenvolvido por:",
+		"loading": "Carregando..."
+	},
+	"schedule": {
+		"recurrence": "Recorrência",
+		"noRecurrence": "Sem recorrência",
+		"daily": "Diário",
+		"weekly": "Semanal",
+		"monthly": "Mensal",
+		"datePlaceholder": "data"
+	},
+	"sounds": {
+		"default": "Som padrão",
+		"chime": "Sino",
+		"achievement": "Sinos de conquista",
+		"relaxingBell": "Sino relaxante"
+	},
+	"system": {
+		"errorTitle": "Erro",
+		"createNoteError": "Não foi possível criar a nota.",
+		"noNotesToOpen": "Você não tem nenhuma nota para abrir!",
+		"alarmForNote": "Alarme da nota: {{content}}"
+	},
+	"language": {
+		"en": "English",
+		"pt-BR": "Português",
+		"es": "Español"
+	}
+}

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -52,6 +52,7 @@
 	"language": {
 		"en": "English",
 		"pt-BR": "Português",
-		"es": "Español"
+		"es": "Español",
+		"label": "Idioma"
 	}
 }

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -7,7 +7,8 @@
 		"deleteAllNotes": "Excluir todas as notas",
 		"startupWithSystem": "Iniciar com o sistema",
 		"about": "Sobre",
-		"quit": "Sair"
+		"quit": "Sair",
+		"closeWindow": "Fechar janela principal"
 	},
 	"note": {
 		"loading": "Carregando nota...",
@@ -24,7 +25,8 @@
 		"chromeVersion": "Versão do Chrome:",
 		"platformAndArch": "Plataforma e arquitetura:",
 		"developedBy": "Desenvolvido por:",
-		"loading": "Carregando..."
+		"loading": "Carregando...",
+		"closeWindow": "Fechar janela Sobre"
 	},
 	"schedule": {
 		"recurrence": "Recorrência",
@@ -32,7 +34,8 @@
 		"daily": "Diário",
 		"weekly": "Semanal",
 		"monthly": "Mensal",
-		"datePlaceholder": "data"
+		"datePlaceholder": "data",
+		"scheduleDateLabel": "Data e hora do agendamento"
 	},
 	"sounds": {
 		"default": "Som padrão",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import { useState, useEffect } from 'react'
 import { api } from '@/libs/api'
 import i18n from './i18n'
 
-const Root = () => {
+export const Root = () => {
 	const [localeReady, setLocaleReady] = useState(false)
 
 	useEffect(() => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,33 @@
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import './i18n'
 import { HashRouter } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { api } from '@/libs/api'
+import i18n from './i18n'
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-	<HashRouter>
-		<App />
-	</HashRouter>
-)
+const Root = () => {
+	const [localeReady, setLocaleReady] = useState(false)
+
+	useEffect(() => {
+		api
+			.getLocale()
+			.then((locale) => i18n.changeLanguage(locale))
+			.then(() => setLocaleReady(true))
+			.catch((err) => {
+				console.error('[Root] getLocale failed:', err)
+				setLocaleReady(true)
+			})
+	}, [])
+
+	if (!localeReady) return null
+
+	return (
+		<HashRouter>
+			<App />
+		</HashRouter>
+	)
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<Root />)

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { vi } from 'vitest'
+import '../i18n'
 
 const electronMock = {
 	getInitialState: vi.fn(() => Promise.resolve(undefined)),

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -36,6 +36,12 @@ const electronMock = {
 	),
 	getAutoStart: vi.fn(() => Promise.resolve(false)),
 	setAutoStart: vi.fn(() => Promise.resolve(true)),
+	getLocale: vi.fn(() => Promise.resolve('en')),
+	setLocale: vi.fn(() => Promise.resolve()),
+	onLocaleUpdated: vi.fn((callback: (locale: string) => void) => {
+		const unsubscribe = vi.fn()
+		return unsubscribe
+	}),
 }
 
 const win = globalThis.window as Window & {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -39,7 +39,7 @@ const electronMock = {
 	setAutoStart: vi.fn(() => Promise.resolve(true)),
 	getLocale: vi.fn(() => Promise.resolve('en')),
 	setLocale: vi.fn(() => Promise.resolve()),
-	onLocaleUpdated: vi.fn((callback: (locale: string) => void) => {
+	onLocaleUpdated: vi.fn(() => {
 		const unsubscribe = vi.fn()
 		return unsubscribe
 	}),

--- a/src/windows/about/index.tsx
+++ b/src/windows/about/index.tsx
@@ -1,9 +1,11 @@
 import { useState, useLayoutEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import './styles.css'
 import { X } from 'lucide-react'
 import { api } from '@/libs/api'
 
 const AboutWindow = () => {
+	const { t } = useTranslation('about')
 	const [info, setInfo] = useState<Awaited<ReturnType<typeof api.getAboutInfo>> | null>(null)
 
 	useLayoutEffect(() => {
@@ -15,39 +17,39 @@ const AboutWindow = () => {
 			{info ? (
 				<main className='about-container'>
 					<header className='top-bar'>
-						<button type='button' title='close' aria-label='Close about window' onClick={api.closeAboutWindow}>
+						<button type='button' title='close' aria-label={t('closeWindow')} onClick={api.closeAboutWindow}>
 							<X color='#FFFFFF' />
 						</button>
 					</header>
 					<h1 className='app-name'>Notifica Task</h1>
 					<div className='info'>
 						<p>
-							<strong>Version: </strong>
+							<strong>{t('version')} </strong>
 							{info.appVersion}
 						</p>
 
 						<p>
-							<strong>Electron Version: </strong>
+							<strong>{t('electronVersion')} </strong>
 							{info.electronVersion}
 						</p>
 
 						<p>
-							<strong>Node Version: </strong>
+							<strong>{t('nodeVersion')} </strong>
 							{info.nodeVersion}
 						</p>
 
 						<p>
-							<strong>Chrome Version: </strong>
+							<strong>{t('chromeVersion')} </strong>
 							{info.chromeVersion}
 						</p>
 
 						<p>
-							<strong>Platform and Architecture: </strong>
+							<strong>{t('platformAndArch')} </strong>
 							{info.platform} ({info.arch})
 						</p>
 
 						<p>
-							<strong>Developed by: </strong>
+							<strong>{t('developedBy')} </strong>
 							<a href='https://github.com/Odisseu93' target='_blank' rel='noopener noreferrer'>
 								Odisseu93 - Ulisses Silvério
 							</a>
@@ -55,7 +57,7 @@ const AboutWindow = () => {
 					</div>
 				</main>
 			) : (
-				<span>Loading...</span>
+				<span>{t('loading')}</span>
 			)}
 		</>
 	)

--- a/src/windows/about/index.tsx
+++ b/src/windows/about/index.tsx
@@ -17,7 +17,7 @@ const AboutWindow = () => {
 			{info ? (
 				<main className='about-container'>
 					<header className='top-bar'>
-						<button type='button' title='close' aria-label={t('closeWindow')} onClick={api.closeAboutWindow}>
+						<button type='button' title={t('closeWindow')} aria-label={t('closeWindow')} onClick={api.closeAboutWindow}>
 							<X color='#FFFFFF' />
 						</button>
 					</header>

--- a/src/windows/main/index.test.tsx
+++ b/src/windows/main/index.test.tsx
@@ -1,7 +1,7 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import React from 'react'
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import MainWindow from './index'
 
 describe('MainWindow', () => {
@@ -24,5 +24,15 @@ describe('MainWindow', () => {
 		render(<MainWindow />)
 		await screen.findByText('About')
 		expect(screen.getByText('Quit')).toBeInTheDocument()
+	})
+
+	it('renders language switcher and calls setLocale when selection changes', async () => {
+		render(<MainWindow />)
+		await screen.findByRole('main')
+		const langSelect = screen.getByRole('combobox', { name: /language/i })
+		expect(langSelect).toBeInTheDocument()
+		expect(screen.getByText('English')).toBeInTheDocument()
+		fireEvent.change(langSelect, { target: { value: 'pt-BR' } })
+		expect(window.electron.setLocale).toHaveBeenCalledWith('pt-BR')
 	})
 })

--- a/src/windows/main/index.test.tsx
+++ b/src/windows/main/index.test.tsx
@@ -8,7 +8,7 @@ describe('MainWindow', () => {
 	it('renders main container and header', async () => {
 		render(<MainWindow />)
 		await screen.findByRole('main')
-		expect(screen.getByTitle('close')).toBeInTheDocument()
+		expect(screen.getByTitle('Close main window')).toBeInTheDocument()
 	})
 
 	it('renders sound label and action buttons', async () => {
@@ -34,5 +34,30 @@ describe('MainWindow', () => {
 		expect(screen.getByText('English')).toBeInTheDocument()
 		fireEvent.change(langSelect, { target: { value: 'pt-BR' } })
 		expect(window.electron.setLocale).toHaveBeenCalledWith('pt-BR')
+	})
+
+	it('shows all menu items visible (no overflow hiding content)', async () => {
+		render(<MainWindow />)
+		await screen.findByRole('main')
+		expect(screen.getByText('Sound:')).toBeVisible()
+		expect(screen.getByText('New note')).toBeVisible()
+		expect(screen.getByText('Close all notes')).toBeVisible()
+		expect(screen.getByText('Open all notes')).toBeVisible()
+		expect(screen.getByText('Delete all notes')).toBeVisible()
+		expect(screen.getByLabelText('Startup with system')).toBeVisible()
+		expect(screen.getByRole('combobox', { name: /language/i })).toBeVisible()
+		expect(screen.getByText('About')).toBeVisible()
+		expect(screen.getByText('Quit')).toBeVisible()
+	})
+
+	it('menu has scrollable content wrapper so window can stay within viewport', async () => {
+		render(<MainWindow />)
+		await screen.findByRole('main')
+		const menuContent = screen.getByTestId('menu-content')
+		expect(menuContent).toBeInTheDocument()
+		expect(menuContent).toHaveClass('menu-content')
+		expect(menuContent).toContainElement(screen.getByText('Sound:'))
+		expect(menuContent).toContainElement(screen.getByText('About'))
+		expect(menuContent).toContainElement(screen.getByText('Quit'))
 	})
 })

--- a/src/windows/main/index.tsx
+++ b/src/windows/main/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import './styles.css'
 
 import { api } from '@/libs/api'
@@ -10,7 +11,10 @@ import MainWindowButton from '@/components/main-window-button'
 import { X } from 'lucide-react'
 
 const MainWindow = () => {
-	const soundList = Object.entries(AlarmSounds).map(([key, sound]) => ({ key, value: sound.name }))
+	const { t } = useTranslation('main')
+	const { t: tSounds } = useTranslation('sounds')
+	const { t: tSystem } = useTranslation('system')
+	const soundList = Object.entries(AlarmSounds).map(([key]) => ({ key, value: tSounds(key) }))
 	const [defaultSoundValue, setDefaultSoundValue] = useState('')
 	const [autoStart, setAutoStart] = useState(false)
 
@@ -56,7 +60,7 @@ const MainWindow = () => {
 								new AppNotification({
 									title: '',
 									requireInteraction: true,
-									body: `🔔 Alarm for note: ${note.content.substring(0, 50)}...`,
+									body: `🔔 ${tSystem('alarmForNote', { content: note.content.substring(0, 50) })}...`,
 									soundKey,
 									loop: true,
 								})
@@ -97,12 +101,12 @@ const MainWindow = () => {
 	return (
 		<main className='container'>
 			<header className='header'>
-				<button type='button' title='close' aria-label='Close main window' onClick={api.hideMainWindow}>
+				<button type='button' title='close' aria-label={t('closeWindow')} onClick={api.hideMainWindow}>
 					<X color='#FFFFFF' />
 				</button>
 			</header>
 			<CustomSelect
-				label='Sound:'
+				label={t('soundLabel')}
 				list={soundList}
 				defaultValue={defaultSoundValue}
 				key={defaultSoundValue}
@@ -110,20 +114,20 @@ const MainWindow = () => {
 					api.setNotificationSound(value)
 				}}
 			/>
-			<MainWindowButton onClick={api.createNewNote} content='New note' />
-			<MainWindowButton onClick={api.closeAllNotes} content='Close all notes' />
-			<MainWindowButton onClick={api.openAllNotes} content='Open all notes' />
-			<MainWindowButton className='text-[tomato]' onClick={api.deleteAllNotes} content='Delete all notes' />
+			<MainWindowButton onClick={api.createNewNote} content={t('newNote')} />
+			<MainWindowButton onClick={api.closeAllNotes} content={t('closeAllNotes')} />
+			<MainWindowButton onClick={api.openAllNotes} content={t('openAllNotes')} />
+			<MainWindowButton className='text-[tomato]' onClick={api.deleteAllNotes} content={t('deleteAllNotes')} />
 
 			<div className='start-up-with-system-container'>
 				<input type='checkbox' id='autoStart' checked={autoStart} onChange={handleToggleAutoStart} />
-				<label htmlFor='autoStart'>Startup with system</label>
+				<label htmlFor='autoStart'>{t('startupWithSystem')}</label>
 			</div>
 			<button className='about-button' onClick={api.openAboutWindow}>
-				About
+				{t('about')}
 			</button>
 			<button className='quit-button' onClick={api.closeApp}>
-				Quit
+				{t('quit')}
 			</button>
 		</main>
 	)

--- a/src/windows/main/index.tsx
+++ b/src/windows/main/index.tsx
@@ -103,11 +103,12 @@ const MainWindow = () => {
 	return (
 		<main className='container'>
 			<header className='header'>
-				<button type='button' title='close' aria-label={t('closeWindow')} onClick={api.hideMainWindow}>
+				<button type='button' title={t('closeWindow')} aria-label={t('closeWindow')} onClick={api.hideMainWindow}>
 					<X color='#FFFFFF' />
 				</button>
 			</header>
-			<CustomSelect
+			<div className='menu-content' data-testid='menu-content'>
+				<CustomSelect
 				label={t('soundLabel')}
 				list={soundList}
 				defaultValue={defaultSoundValue}
@@ -147,6 +148,7 @@ const MainWindow = () => {
 			<button className='quit-button' onClick={api.closeApp}>
 				{t('quit')}
 			</button>
+			</div>
 		</main>
 	)
 }

--- a/src/windows/main/index.tsx
+++ b/src/windows/main/index.tsx
@@ -9,11 +9,13 @@ import { now, getNextRecurrenceDate } from '@/utils/date'
 import CustomSelect from '../../components/custom-select'
 import MainWindowButton from '@/components/main-window-button'
 import { X } from 'lucide-react'
+import i18n from '@/i18n'
 
 const MainWindow = () => {
 	const { t } = useTranslation('main')
 	const { t: tSounds } = useTranslation('sounds')
 	const { t: tSystem } = useTranslation('system')
+	const { t: tLanguage } = useTranslation('language')
 	const soundList = Object.entries(AlarmSounds).map(([key]) => ({ key, value: tSounds(key) }))
 	const [defaultSoundValue, setDefaultSoundValue] = useState('')
 	const [autoStart, setAutoStart] = useState(false)
@@ -122,6 +124,22 @@ const MainWindow = () => {
 			<div className='start-up-with-system-container'>
 				<input type='checkbox' id='autoStart' checked={autoStart} onChange={handleToggleAutoStart} />
 				<label htmlFor='autoStart'>{t('startupWithSystem')}</label>
+			</div>
+			<div className='language-switcher-container'>
+				<label htmlFor='locale' className='language-label'>
+					{tLanguage('label')}
+				</label>
+				<select
+					id='locale'
+					role='combobox'
+					aria-label={tLanguage('label')}
+					value={i18n.language}
+					onChange={(e) => api.setLocale(e.target.value)}
+				>
+					<option value='en'>{tLanguage('en')}</option>
+					<option value='pt-BR'>{tLanguage('pt-BR')}</option>
+					<option value='es'>{tLanguage('es')}</option>
+				</select>
 			</div>
 			<button className='about-button' onClick={api.openAboutWindow}>
 				{t('about')}

--- a/src/windows/main/styles.css
+++ b/src/windows/main/styles.css
@@ -2,13 +2,18 @@
 @import "tw-animate-css";
 
 .container {
-  @apply flex flex-col gap-4 px-4 py-16;
+  @apply flex flex-col h-full min-h-0;
 }
 
-.container>header {
+.container > header {
   background-color: var(--color-black-1);
-  @apply absolute left-0 top-0 h-[32px] w-full flex justify-end items-center p-2;
+  @apply flex-shrink-0 left-0 top-0 h-[32px] w-full flex justify-end items-center p-2;
   -webkit-app-region: drag;
+}
+
+.container .menu-content {
+  @apply flex flex-col gap-4 px-4 py-4 overflow-y-auto flex-1 min-h-0;
+  max-width: 280px;
 }
 
 button {
@@ -16,7 +21,7 @@ button {
 }
 
 .start-up-with-system-container {
-  @apply flex items-center gap-2;
+  @apply flex items-center gap-2 max-w-[280px];
 }
 
 .start-up-with-system-container>input {
@@ -25,5 +30,14 @@ button {
 
 .about-button,
 .quit-button {
-  @apply bg-transparent w-max m-0 p-0 border-none active:scale-95;
+  @apply bg-transparent w-full m-0 p-0 border-none active:scale-95 text-left block;
+}
+
+.language-switcher-container {
+  @apply flex flex-col gap-1;
+}
+.language-switcher-container select {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
 }

--- a/src/windows/note/index.tsx
+++ b/src/windows/note/index.tsx
@@ -88,22 +88,22 @@ const NoteWindow = () => {
 	return (
 		<article className='card' id={note.id}>
 			<header>
-				<button type='button' title='add note' aria-label={t('addNote')} onClick={handleCreate}>
+				<button type='button' title={t('addNote')} aria-label={t('addNote')} onClick={handleCreate}>
 					<Plus color='#FFFFFF' />
 				</button>
 				<div className='close-and-ellipse-button'>
-					<button type='button' title='menu' aria-label={t('openMenu')} onClick={handleToggleMenu}>
+					<button type='button' title={t('openMenu')} aria-label={t('openMenu')} onClick={handleToggleMenu}>
 						<Ellipsis color='#FFFFFF' />
 					</button>
 					<ul className={`menu menu--${isMenuEnabled ? 'enabled' : 'disabled'}`}>
 						<li>
-							<button title='delete' type='button' className='text-[tomato]' aria-label={t('deleteNote')} onClick={handleDelete}>
+							<button title={t('deleteNote')} type='button' className='text-[tomato]' aria-label={t('deleteNote')} onClick={handleDelete}>
 								<Trash2 color='#141414' />
 								<span className='button-text'>{t('deleteNote')}</span>
 							</button>
 						</li>
 					</ul>
-					<button type='button' title='close' aria-label={t('closeNote')} onClick={handleClose}>
+					<button type='button' title={t('closeNote')} aria-label={t('closeNote')} onClick={handleClose}>
 						<X color='#FFFFFF' />
 					</button>
 				</div>

--- a/src/windows/note/index.tsx
+++ b/src/windows/note/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import './styles.css'
 
 import NotificationSchedule from '@/components/notification-schedule'
@@ -9,6 +10,7 @@ import { api } from '@/libs/api'
 import { Note } from 'interfaces/note-interface'
 
 const NoteWindow = () => {
+	const { t } = useTranslation('note')
 	const [note, setNote] = useState<Note | null>(null)
 	const [isMenuEnabled, setIsMenuEnabled] = useState(false)
 	const hash = window.location.hash // "#note?noteId=123"
@@ -81,27 +83,27 @@ const NoteWindow = () => {
 		}
 	}, [])
 
-	if (!note) return <div>Loading note...</div>
+	if (!note) return <div>{t('loading')}</div>
 
 	return (
 		<article className='card' id={note.id}>
 			<header>
-				<button type='button' title='add note' aria-label='Add new note' onClick={handleCreate}>
+				<button type='button' title='add note' aria-label={t('addNote')} onClick={handleCreate}>
 					<Plus color='#FFFFFF' />
 				</button>
 				<div className='close-and-ellipse-button'>
-					<button type='button' title='menu' aria-label='Open menu' onClick={handleToggleMenu}>
+					<button type='button' title='menu' aria-label={t('openMenu')} onClick={handleToggleMenu}>
 						<Ellipsis color='#FFFFFF' />
 					</button>
 					<ul className={`menu menu--${isMenuEnabled ? 'enabled' : 'disabled'}`}>
 						<li>
-							<button title='delete' type='button' className='text-[tomato]' aria-label='Delete note' onClick={handleDelete}>
+							<button title='delete' type='button' className='text-[tomato]' aria-label={t('deleteNote')} onClick={handleDelete}>
 								<Trash2 color='#141414' />
-								<span className='button-text'>Delete note</span>
+								<span className='button-text'>{t('deleteNote')}</span>
 							</button>
 						</li>
 					</ul>
-					<button type='button' title='close' aria-label='Close note window' onClick={handleClose}>
+					<button type='button' title='close' aria-label={t('closeNote')} onClick={handleClose}>
 						<X color='#FFFFFF' />
 					</button>
 				</div>
@@ -109,7 +111,7 @@ const NoteWindow = () => {
 			<textarea
 				rows={10}
 				cols={40}
-				placeholder='Meeting at 8 am...'
+				placeholder={t('placeholder')}
 				value={note.content}
 				onChange={handleContentChange}
 			/>

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,7 +196,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/runtime@^7.12.5":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.28.4":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
@@ -3084,6 +3084,13 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+html-parse-stringify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
+  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
+  dependencies:
+    void-elements "3.1.0"
+
 http-cache-semantics@^4.0.0:
   version "4.1.1"
   resolved "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz"
@@ -3117,6 +3124,13 @@ https-proxy-agent@^7.0.0, https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.6:
   dependencies:
     agent-base "^7.1.2"
     debug "4"
+
+i18next@^25.8.14:
+  version "25.8.14"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-25.8.14.tgz#5c3fcbb31014597e01d98a86250803cef836f9a7"
+  integrity sha512-paMUYkfWJMsWPeE/Hejcw+XLhHrQPehem+4wMo+uELnvIwvCG019L9sAIljwjCmEMtFQQO3YeitJY8Kctei3iA==
+  dependencies:
+    "@babel/runtime" "^7.28.4"
 
 iconv-corefoundation@^1.1.7:
   version "1.1.7"
@@ -4103,6 +4117,15 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-i18next@^16.5.6:
+  version "16.5.6"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-16.5.6.tgz#3b541530eac12927515e1825df69c5d9b1ec5924"
+  integrity sha512-Ua7V2/efA88ido7KyK51fb8Ki8M/sRfW8LR/rZ/9ZKr2luhuTI7kwYZN5agT1rWG7aYm5G0RYE/6JR8KJoCMDw==
+  dependencies:
+    "@babel/runtime" "^7.28.4"
+    html-parse-stringify "^3.0.1"
+    use-sync-external-store "^1.6.0"
+
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
@@ -4806,6 +4829,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+use-sync-external-store@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
+
 utf8-byte-length@^1.0.1:
   version "1.0.5"
   resolved "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz"
@@ -4885,6 +4913,11 @@ vitest@^4.0.18:
     tinyrainbow "^3.0.3"
     vite "^6.0.0 || ^7.0.0"
     why-is-node-running "^2.3.0"
+
+void-elements@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
+  integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Resumo
Implementa troca de idioma (i18n) com inglês (padrão), pt-BR e espanhol.

### Incluído
- Store com locale + IPC get/set/onLocaleUpdated
- Arquivos de tradução (en, pt-BR, es) e react-i18next
- UI usando t() em Main, Note, About e NotificationSchedule
- Seletor de idioma na Main window
- Notificações do processo main traduzidas por locale
- Testes e lint ajustados

### Versão
Bump para 1.2.0; CHANGELOG atualizado.

Made with [Cursor](https://cursor.com)